### PR TITLE
Added handling of /var/lib/sss/pipes/nss file

### DIFF
--- a/src/main/java/com/redhat/jigawatts/Jigawatts.java
+++ b/src/main/java/com/redhat/jigawatts/Jigawatts.java
@@ -78,7 +78,9 @@ public class Jigawatts {
         }
 
         writeRestoreHooks(dir);
+        preNativeActions();
         crContext.saveTheWorldNative(dir, leaveRunning);
+        postNativeActions();
     }
 
     public static void saveTheWorld(String dir) throws IOException {
@@ -117,12 +119,23 @@ public class Jigawatts {
     }
 
     public static void restoreTheWorld(String dir) throws IOException {
+        preNativeActions();
         crContext.restoreTheWorldNative(dir);
+        postNativeActions();
         readRestoreHooks(dir);
         for (Hook h : restoreHooks) {
             h.run();
         }
     }
+
+    private static void postNativeActions() throws IOException {
+        SssPipeNssFileException.restoreSssNssFile();
+    }
+
+    private static void preNativeActions() throws IOException {
+        SssPipeNssFileException.closeSssNssFile();
+    }
+
 
     public static void registerCheckpointHook(Hook h) {
         crContext.checkpointHooks.add(h);

--- a/src/main/java/com/redhat/jigawatts/LibraryLoader.java
+++ b/src/main/java/com/redhat/jigawatts/LibraryLoader.java
@@ -35,7 +35,7 @@ class LibraryLoader {
         }
     }
 
-    private static void jigaLog(String s) {
+    static void jigaLog(String s) {
         if (getVerbose()) {
             if (getVerboseFile() == null) {
                 System.err.println(s);
@@ -92,6 +92,10 @@ class LibraryLoader {
         return getPropertyOrVar(LIBRARY_EXTERNAL_PROP);
     }
 
+    static String getSssNss() {
+        return getPropertyOrVar(SSS_NSS);
+    }
+
     private static void loadInJarLibrary() {
         File tmpLibrary = null;
         try {
@@ -130,6 +134,10 @@ class LibraryLoader {
     private static final String LIBRARY_EXTERNAL_PROP = "jigawatts.library";
     private static final String VERBOSE_PROP = "jigawatts.verbose";
     private static final String VERBOSE_FILE_PROP = "jigawatts.verbose.file";
+    static final String SSS_NSS = "jigawatts.ssspipesnss";
+    static final String SSS_NSS_IGNORE = "ignore";
+    static final String SSS_NSS_FORCE = "force";
+    static final String SSS_NSS_FIERCE = "fierce";
     private static final String SYSTEM_LIB_SWITCH = "SYSTEM";
 
     static void loadLibrary() {
@@ -172,5 +180,15 @@ class LibraryLoader {
         System.out.println("    " + PROP + VERBOSE_FILE_PROP + "/" + VAR + propertyToVar(VERBOSE_FILE_PROP) + ": " + getVerboseFile());
         System.out.println(" * This switch can set library loading logging to append to exact file instead of stderr");
         System.out.println("    " + PROP + VERBOSE_PROP + "/" + VAR + propertyToVar(VERBOSE_PROP) + ": " + getVerbose());
+        System.out.println(" * " + sssNssLine1());
+        System.out.println("    " + sssNssLine2());
+    }
+
+    static String sssNssLine1() {
+        return "criu do not work if " + SssPipeNssFileException.SSS_NSS_FILE + " exists. By default we throw exception, if we should try, set following variable to `" + SSS_NSS_IGNORE + "`. Use `" + SSS_NSS_FORCE + "` to let us delete it and resore it afterwards. Set `"+SSS_NSS_FIERCE+"`, similar to "+SSS_NSS_FORCE+", but ignoring any exceptions";
+    }
+
+    static String sssNssLine2() {
+        return PROP + SSS_NSS + "/" + VAR + propertyToVar(SSS_NSS) + ": " + getSssNss();
     }
 }

--- a/src/main/java/com/redhat/jigawatts/SssPipeNssFileException.java
+++ b/src/main/java/com/redhat/jigawatts/SssPipeNssFileException.java
@@ -1,0 +1,85 @@
+package com.redhat.jigawatts;
+
+import java.io.File;
+import java.io.IOException;
+
+public class SssPipeNssFileException extends IOException {
+
+    static final File SSS_NSS_FILE = new File("/var/lib/sss/pipes/nss");
+
+    static void closeSssNssFile() throws IOException {
+        if (LibraryLoader.SSS_NSS_IGNORE.equals(LibraryLoader.getSssNss())) {
+            return;
+        }
+        if (LibraryLoader.getSssNss() == null && SSS_NSS_FILE.exists()) {
+            LibraryLoader.jigaLog(SSS_NSS_FILE + " exists and " + LibraryLoader.SSS_NSS + " is not set.Cowardly exiting");
+            throw new SssPipeNssFileException();
+        }
+        if ((LibraryLoader.SSS_NSS_FIERCE.equals(LibraryLoader.getSssNss()) || LibraryLoader.SSS_NSS_FORCE.equals(LibraryLoader.getSssNss())) && SSS_NSS_FILE.exists()) {
+            LibraryLoader.jigaLog(SSS_NSS_FILE + " exists and " + LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". deleting");
+            boolean deleted = SSS_NSS_FILE.delete();
+            if (!deleted) {
+                LibraryLoader.jigaLog(SSS_NSS_FILE + " removal failed");
+                if (LibraryLoader.SSS_NSS_FORCE.equals(LibraryLoader.getSssNss())) {
+                    LibraryLoader.jigaLog(LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". Cowardly exiting");
+                    throw new SssPipeNssFileException("Failed to delete " + SSS_NSS_FILE);
+                } else {
+                    LibraryLoader.jigaLog(LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". Bravely continuing.");
+                }
+            } else {
+                LibraryLoader.jigaLog(SSS_NSS_FILE + " removal succeeded");
+            }
+        }
+    }
+
+    static void restoreSssNssFile() throws IOException {
+        if (LibraryLoader.SSS_NSS_IGNORE.equals(LibraryLoader.getSssNss())) {
+            return;
+        }
+        if (LibraryLoader.getSssNss() == null) {
+            return;
+        }
+        if ((LibraryLoader.SSS_NSS_FIERCE.equals(LibraryLoader.getSssNss()) || LibraryLoader.SSS_NSS_FORCE.equals(LibraryLoader.getSssNss())) && !SSS_NSS_FILE.exists()) {
+            int authConfResult = -1;
+            String cmd = "authconfig --enablesssd --update";
+            try {
+                LibraryLoader.jigaLog("Executing `" + cmd + "`");
+                Process p = Runtime.getRuntime().exec(cmd);
+                authConfResult = p.waitFor();
+                p.destroy();
+            } catch (Exception ex) {
+                LibraryLoader.jigaLog("cmd fialed: " + ex);
+                if (LibraryLoader.SSS_NSS_FORCE.equals(LibraryLoader.getSssNss())) {
+                    LibraryLoader.jigaLog(LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". Cowardly exiting");
+                    throw new SssPipeNssFileException(ex);
+                } else {
+                    LibraryLoader.jigaLog(LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". Bravely continuing");
+                }
+            }
+            if (authConfResult != 0) {
+                LibraryLoader.jigaLog("cmd exited nonzero: " + authConfResult);
+                if (LibraryLoader.SSS_NSS_FORCE.equals(LibraryLoader.getSssNss())) {
+                    LibraryLoader.jigaLog(LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". Cowardly exiting");
+                    throw new SssPipeNssFileException("Failed to restore " + SSS_NSS_FILE + " cmd `" + cmd + "` exited with:" + authConfResult);
+                } else {
+                    LibraryLoader.jigaLog(LibraryLoader.SSS_NSS + " is set to " + LibraryLoader.getSssNss() + ". Bravely continuing");
+                }
+            } else {
+                LibraryLoader.jigaLog("cmd succeeded.");
+            }
+        }
+    }
+
+    public SssPipeNssFileException() {
+        super(LibraryLoader.sssNssLine1() + ";" + LibraryLoader.sssNssLine2());
+    }
+
+    public SssPipeNssFileException(String s) {
+        super(s);
+    }
+
+    public SssPipeNssFileException(Exception ex) {
+        super(ex);
+    }
+
+}


### PR DESCRIPTION
By default, if the file exists, exception is thrown.
You can set -Djigawatts.ssspipesnss to ignore to behave as before - to
die cryptically
Also you may set it to force, which will try to remove file before criu
actions and resore afterwards. If anything goes wrong, it throws.
Last choice is fierce, which is as force, but do not die if removal or
restore of file goes bad